### PR TITLE
歩行者コントローラのリファクタ

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -171,10 +171,10 @@ MonoBehaviour:
   - {fileID: 599458233}
   - {fileID: 613468329}
   pedestrianPrefab: {fileID: 802560460005980580, guid: 49fcbaa91a57fc641ae87a8452e6bdee, type: 3}
-  S2GPedestrianCount: 10
-  G2SPedestrianCount: 10
-  ratioStationary: 10
-  ratioReversing: 10
+  S2GPedestrianCount: 7
+  G2SPedestrianCount: 7
+  ratioStationary: 8
+  ratioReversing: 4
 --- !u!1001 &200762909
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -313,6 +313,10 @@ PrefabInstance:
       value: road-straight (2)
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
@@ -387,6 +391,10 @@ PrefabInstance:
       value: tile-low (3)
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
@@ -459,6 +467,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
       propertyPath: m_Name
       value: tile-low (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -610,6 +622,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_Name
       value: road-straight (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -840,6 +856,10 @@ PrefabInstance:
       value: tile-low (2)
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
@@ -912,6 +932,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_Name
       value: road-straight (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -1133,7 +1157,7 @@ MonoBehaviour:
   m_Center: {x: 0, y: 2, z: 0}
   m_LayerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 8
   m_UseGeometry: 0
   m_DefaultArea: 0
   m_GenerateLinks: 0
@@ -1223,6 +1247,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
       propertyPath: m_Name
       value: tile-low
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: e40ef213054268d45a8fe27e3ec3a37f, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -1402,10 +1430,10 @@ MonoBehaviour:
   - {fileID: 1209871199}
   - {fileID: 1044163970}
   pedestrianPrefab: {fileID: 802560460005980580, guid: 49fcbaa91a57fc641ae87a8452e6bdee, type: 3}
-  S2GPedestrianCount: 10
-  G2SPedestrianCount: 10
-  ratioStationary: 10
-  ratioReversing: 10
+  S2GPedestrianCount: 7
+  G2SPedestrianCount: 7
+  ratioStationary: 8
+  ratioReversing: 4
 --- !u!1 &1016363330
 GameObject:
   m_ObjectHideFlags: 0
@@ -1415,7 +1443,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1016363331}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: Roads
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1636,7 +1664,7 @@ MonoBehaviour:
   m_Center: {x: 0, y: 2, z: 0}
   m_LayerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 8
   m_UseGeometry: 0
   m_DefaultArea: 0
   m_GenerateLinks: 0
@@ -1961,6 +1989,10 @@ PrefabInstance:
       value: road-straight
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
@@ -2102,8 +2134,8 @@ MonoBehaviour:
   - {fileID: 1385704612}
   - {fileID: 2121490482}
   pedestrianPrefab: {fileID: 802560460005980580, guid: 49fcbaa91a57fc641ae87a8452e6bdee, type: 3}
-  S2GPedestrianCount: 10
-  G2SPedestrianCount: 10
+  S2GPedestrianCount: 7
+  G2SPedestrianCount: 7
   ratioStationary: 8
   ratioReversing: 4
 --- !u!1 &1508289106
@@ -2199,10 +2231,10 @@ MonoBehaviour:
   - {fileID: 200762910}
   - {fileID: 1350338871}
   pedestrianPrefab: {fileID: 802560460005980580, guid: 49fcbaa91a57fc641ae87a8452e6bdee, type: 3}
-  S2GPedestrianCount: 10
-  G2SPedestrianCount: 10
-  ratioStationary: 10
-  ratioReversing: 10
+  S2GPedestrianCount: 7
+  G2SPedestrianCount: 7
+  ratioStationary: 8
+  ratioReversing: 4
 --- !u!1001 &1608853070
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2418,6 +2450,10 @@ PrefabInstance:
       value: road-straight
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a736ca5c2ea95fd47a726cd74b93cec8, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 2147483647
       objectReference: {fileID: 0}
@@ -2490,6 +2526,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: d180cbe4d34897e428a076191b2af221, type: 3}
       propertyPath: m_Name
       value: road-crossroad-line
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d180cbe4d34897e428a076191b2af221, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: d180cbe4d34897e428a076191b2af221, type: 3}
       propertyPath: m_StaticEditorFlags
@@ -2586,6 +2626,6 @@ Transform:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
+  - {fileID: 724868575}
   - {fileID: 758116253}
   - {fileID: 1198002566}
-  - {fileID: 724868575}

--- a/Assets/Scripts/PedestrianController.cs
+++ b/Assets/Scripts/PedestrianController.cs
@@ -9,10 +9,11 @@ using Random = UnityEngine.Random;
 [RequireComponent(typeof(NavMeshAgent))]
 public class PedestrianController : MonoBehaviour
 {
+    #region Fields
     // 外部参照
     // - PopulationFlowManager: 左右通行設定などの共有コンフィグ
     // - frontierStart/frontierGoal: 経路の始端・終端ライン
-    [HideInInspector] public PopulationFlowManager PopulationFlowManager;
+    [HideInInspector] public PopulationFlowManager populationFlowManager;
     [HideInInspector] public LineObject frontierStart, frontierGoal;
     /// <summary>
     /// 中間ライン配列（Start → mid[0] → mid[1] → ... → Goal の順序）
@@ -36,31 +37,31 @@ public class PedestrianController : MonoBehaviour
     private NavMeshAgent navMeshAgent;
     private Vector3 destination;
     private Animator cachedAnimator;
+    // サイクル（生成〜到達）中に維持する横方向の割合（0..1）
+    private float lateralRatio = 0.5f;
 
     // 中間ライン制御
     private int currentTargetLineIndex = 0; // 次に目指すラインのインデックス（0～intermediateLines.Count）
     // - S2Gの場合: 0は最初の中間ライン（中間ライン無し時はゴールライン）、intermediateLines.Countはゴールライン
     // - G2Sの場合: 0は最初の目的ライン（ゴールライン）、intermediateLines.Countはスタートライン
-    
+
+    // 1サイクル（生成/リセット〜最終到達）間で再利用する、進行方向順のライン列
+    private List<LineObject> orderedLines;
+
     // 外部（Managerなど）から参照するためのキャッシュ済み Animator アクセサ
     public Animator CachedAnimator => cachedAnimator;
+    #endregion
 
+    #region Unity Lifecycle
     private void Awake()
     {
         // 頻繁にアクセスするコンポーネント参照をキャッシュして、GetComponentの頻度を下げる
         navMeshAgent = GetComponent<NavMeshAgent>();
         cachedAnimator = GetComponent<Animator>();
     }
+    #endregion
 
-    // 指定座標に歩行者をワープさせる
-    private void WarpOrSetPosition(Vector3 position)
-    {
-        if (navMeshAgent.isActiveAndEnabled)
-            navMeshAgent.Warp(position);
-        else
-            transform.position = position;
-    }
-
+    #region Public API
     // 歩行者の初期位置と方向を設定
     public void InitializePosition(bool isLeftSideTraffic)
     {
@@ -68,6 +69,9 @@ public class PedestrianController : MonoBehaviour
 
         // 中間ライン追跡状態をリセット（最初のセグメントから再開）
         currentTargetLineIndex = 0;
+
+        // サイクル用ライン列を構築
+        orderedLines = GetAllLinesOrdered(isS2G);
 
         // 初期位置と目的地を計算してセットアップ
         var positionData = CalculateInitialPosition(isLeftSideTraffic);
@@ -88,91 +92,10 @@ public class PedestrianController : MonoBehaviour
             }
         }
     }
+    #endregion
 
-    // 初期位置と目的地を計算
-    private (Vector3 position, Vector3 destination) CalculateInitialPosition(bool isLeftSideTraffic)
-    {
-        var lines = GetAllLinesOrdered(isS2G);
-
-        // 初期セグメントの選定：両端(Start/Goal)を避け、中間セグメントを優先
-        int minSegIndex = 1;
-        int maxSegIndex = lines.Count - 2;
-        int segIndex;
-        if (minSegIndex >= maxSegIndex)
-        {
-            Debug.LogWarning("ライン数が不足しています。スタート・ゴールを各１つ中間ライン２つ以上を設定してください。");
-            segIndex = Random.Range(0, lines.Count - 1);
-        }
-        else
-        {
-            // minSegIndex 以上 maxSegIndex 未満の範囲でランダム選択
-            segIndex = Random.Range(minSegIndex, maxSegIndex);
-        }
-
-        LineObject src = lines[segIndex];
-        LineObject dst = lines[segIndex + 1];
-
-        // セグメントの進行方向（中心点同士のベクトル）
-        Vector3 forward = (dst.GetCenter() - src.GetCenter()).normalized;
-
-        // 通行ルール（左右通行）に対応するオフセット幅を決定
-        float halfLen = src.GetLength() * 0.5f;
-        bool useLeft = ShouldUseLeftSide(isLeftSideTraffic);
-        float offset = Random.Range(0f, halfLen);
-
-        // src上の左右側点 p0 と、それに対応するdst上の点 p1 を取得
-        Vector3 p0 = GetSidePositionOnLine(src, forward, useLeft, offset);
-        Vector3 p1 = GetCorrespondingPointOnLine(p0, src, dst);
-
-        // p0-p1間のランダム位置を初期位置とする
-        Vector3 spawnPos = Vector3.Lerp(p0, p1, Random.value);
-
-        // NavMesh上へスナップ
-        Vector3 position = SnapToNavMeshXZ(spawnPos);
-
-        // 現在のターゲットセグメントを保持（source=segIndex, target=segIndex+1）
-        currentTargetLineIndex = segIndex;
-
-        // 初期の目的地は p1（dst対応点）を使用
-        return (position, p1);
-    }
-
-    /// <summary>
-    /// 全ラインを進行方向順（S2G/G2S）に整列して返す
-    /// </summary>
-    private List<LineObject> GetAllLinesOrdered(bool s2g)
-    {
-        var list = new List<LineObject> { frontierStart };
-        if (intermediateLines != null)
-        {
-            list.AddRange(intermediateLines);
-        }
-        list.Add(frontierGoal);
-
-        // G2S の場合は反転
-        if (!s2g)
-        {
-            list.Reverse();
-        }
-
-        return list;
-    }
-
-
-    // 指定位置に歩行者をセットアップ（目的地設定・速度等の個体差を適用）
-    private void SetupPedestrianAtPosition(Vector3 position, Vector3 targetDestination)
-    {
-        destination = targetDestination;
-        WarpOrSetPosition(position);
-        ApplyRandomMovementParams();
-        if (!isStationaryPedestrian)
-        {
-            navMeshAgent.SetDestination(destination);
-            AlignWithDestination(); // 初期向きを目的地方向に合わせる
-        }
-    }
-
-        // ライン到達時
+    #region Unity Events
+    // ライン到達時
     private void OnTriggerEnter(Collider other)
     {
         if (isStationaryPedestrian) return; // 停止者は衝突無視
@@ -209,11 +132,29 @@ public class PedestrianController : MonoBehaviour
             }
         }
     }
+    #endregion
+
+    #region High-level Workflow
+    // 指定位置に歩行者をセットアップ
+    private void SetupPedestrianAtPosition(Vector3 position, Vector3 targetDestination)
+    {
+        destination = targetDestination;
+        WarpOrSetPosition(position);
+        ApplyRandomMovementParams();
+        if (!isStationaryPedestrian)
+        {
+            navMeshAgent.SetDestination(destination);
+            AlignWithDestination(); // 初期向きを目的地方向に合わせる
+        }
+    }
 
     // 目的地を超えたら位置をリセットして再度歩行開始（循環）
     private void ResetPosition()
     {
         if (frontierStart == null || frontierGoal == null || !navMeshAgent.isOnNavMesh) return;
+
+        // サイクル用ライン列を再構築（初期生成時と同等に固定化）
+        orderedLines = GetAllLinesOrdered(isS2G);
 
         // 再配置：現在のセグメントの左右半区間上にランダムに再配置
         Vector3 resetPosition = CalculateResetPosition();
@@ -226,6 +167,80 @@ public class PedestrianController : MonoBehaviour
         {
             AlignWithDestination();
         }
+    }
+
+    // 目的地を設定：現在位置の対応点を次ターゲットライン上に求め、NavMeshAgentへ指示
+    private void SetDestination()
+    {
+        if (frontierStart == null || frontierGoal == null) return;
+        if (isStationaryPedestrian) return; // 停止者は目的地設定不要
+
+        // サイクルで保持している横割合で次ターゲットライン上の目的地を決定
+        LineObject targetLine = GetCurrentTargetLine();
+        if (targetLine == null) return;
+        destination = Vector3.Lerp(targetLine.LeftPoint, targetLine.RightPoint, lateralRatio);
+        navMeshAgent.SetDestination(destination);
+    }
+
+    // 進行方向に歩行者の向きを合わせる（Y軸回りのみ回転）
+    private void AlignWithDestination()
+    {
+        Vector3 direction = destination - transform.position;
+        direction.y = 0;
+
+        if (direction != Vector3.zero)
+        {
+            transform.rotation = Quaternion.LookRotation(direction);
+        }
+    }
+    #endregion
+
+    #region Mid-level Calculations
+    // 初期位置と目的地を計算
+    private (Vector3 position, Vector3 destination) CalculateInitialPosition(bool isLeftSideTraffic)
+    {
+        // 初期化されていなければライン列を構築
+        var lines = orderedLines ?? (orderedLines = GetAllLinesOrdered(isS2G));
+
+        // 初期セグメントの選定：両端(Start/Goal)を避け、中間セグメントを優先
+        int minSegIndex = 1;
+        int maxSegIndex = lines.Count - 2;
+        int segIndex;
+        if (minSegIndex >= maxSegIndex)
+        {
+            Debug.LogWarning("ライン数が不足しています。スタート・ゴールを各１つ中間ライン２つ以上を設定してください。");
+            segIndex = Random.Range(0, lines.Count - 1);
+        }
+        else
+        {
+            // minSegIndex 以上 maxSegIndex 未満の範囲でランダム選択
+            segIndex = Random.Range(minSegIndex, maxSegIndex);
+        }
+
+        LineObject src = lines[segIndex];
+        LineObject dst = lines[segIndex + 1];
+
+        // Lerpベースに統一：進行方向に対する左右とラインの Left/Right の関係から横割合を決定
+        bool useLeft = ShouldUseLeftSide(isLeftSideTraffic);
+        lateralRatio = ChooseLateralRatioForSegment(src, dst, useLeft);
+
+        // 決定した割合で source ライン上の対応点を取得（Lerp）
+        Vector3 p0 = Vector3.Lerp(src.LeftPoint, src.RightPoint, lateralRatio);
+
+        // 次ライン上では同じ割合の点を目的地にする
+        Vector3 p1 = Vector3.Lerp(dst.LeftPoint, dst.RightPoint, lateralRatio);
+
+        // p0-p1間のランダム位置を初期位置とする
+        Vector3 spawnPos = Vector3.Lerp(p0, p1, Random.value);
+
+        // NavMesh上へスナップ
+        Vector3 position = SnapToNavMeshXZ(spawnPos);
+
+        // 現在のターゲットセグメントを保持（source=segIndex, target=segIndex+1）
+        currentTargetLineIndex = segIndex;
+
+        // 初期の目的地は p1（dst対応点）を使用
+        return (position, p1);
     }
 
     // リセット位置を計算
@@ -249,17 +264,58 @@ public class PedestrianController : MonoBehaviour
                 : frontierStart;
         }
 
-        // 進行方向ベクトル
-        Vector3 forward = (targetLine.GetCenter() - sourceLine.GetCenter()).normalized;
+        // Lerpベースに統一：進行方向に対する左右とラインの Left/Right の関係から横割合を決定
+        bool useLeft = ShouldUseLeftSide(populationFlowManager.IsLeftSideTraffic);
+        lateralRatio = ChooseLateralRatioForSegment(sourceLine, targetLine, useLeft);
 
-        // 片側幅の範囲でランダムオフセット
-        float halfLength = sourceLine.GetLength() * 0.5f;
-        bool useLeft = ShouldUseLeftSide(PopulationFlowManager.IsLeftSideTraffic);
-        float offset = Random.Range(0f, halfLength);
-
-        // 並進位置を算出し、NavMeshへスナップ
-        Vector3 basePos = GetSidePositionOnLine(sourceLine, forward, useLeft, offset);
+        // 決定した割合の位置へ再配置（Lerp）
+        Vector3 basePos = Vector3.Lerp(sourceLine.LeftPoint, sourceLine.RightPoint, lateralRatio);
         return SnapToNavMeshXZ(basePos);
+    }
+
+    /// <summary>
+    /// 全ラインを進行方向順（S2G/G2S）に整列して返す
+    /// </summary>
+    private List<LineObject> GetAllLinesOrdered(bool s2g)
+    {
+        var list = new List<LineObject> { frontierStart };
+        if (intermediateLines != null)
+        {
+            list.AddRange(intermediateLines);
+        }
+        list.Add(frontierGoal);
+
+        // G2S の場合は反転
+        if (!s2g)
+        {
+            list.Reverse();
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// 現在のターゲットラインを取得
+    /// </summary>
+    private LineObject GetCurrentTargetLine()
+    {
+        var lines = orderedLines ?? (orderedLines = GetAllLinesOrdered(isS2G));
+        if (lines == null || lines.Count == 0) return null;
+
+        // 範囲外アクセスを防ぐためにClamp
+        int idx = Mathf.Clamp(currentTargetLineIndex + 1, 1, Mathf.Max(1, lines.Count - 1));
+        return lines[idx];
+    }
+    #endregion
+
+    #region Utilities
+    // 指定座標に歩行者をワープさせる
+    private void WarpOrSetPosition(Vector3 position)
+    {
+        if (navMeshAgent.isActiveAndEnabled)
+            navMeshAgent.Warp(position);
+        else
+            transform.position = position;
     }
 
     // 近傍のNavMesh上にXZを維持したままスナップ（見つからない時は高さのみ現状を保持して返す）
@@ -272,81 +328,6 @@ public class PedestrianController : MonoBehaviour
         }
         // フォールバック：NavMeshが見つからない場合はXZのみ採用
         return new Vector3(approx.x, transform.position.y, approx.z);
-    }
-
-    // あるライン上の点に対応する別ライン上の点を取得
-    private Vector3 GetCorrespondingPointOnLine(Vector3 sourcePoint, LineObject sourceLine, LineObject targetLine)
-    {
-        // sourceLine 左端→右端ベクトル
-        Vector3 sourceLeft = sourceLine.LeftPoint;
-        Vector3 sourceRight = sourceLine.RightPoint;
-        Vector3 sourceVector = sourceRight - sourceLeft;
-
-        // sourcePoint が sourceLine 上でどの割合(0-1)に位置するかを内積から求める
-        float sourceRatio = 0f;
-        float denom = sourceVector.sqrMagnitude;
-        if (denom > Mathf.Epsilon)
-        {
-            sourceRatio = Mathf.Clamp01(Vector3.Dot(sourcePoint - sourceLeft, sourceVector) / denom);
-        }
-
-        // 求めた比率で targetLine の対応点を補間
-        Vector3 targetLeft = targetLine.LeftPoint;
-        Vector3 targetRight = targetLine.RightPoint;
-        return Vector3.Lerp(targetLeft, targetRight, sourceRatio);
-    }
-
-    /// <summary>
-    /// 現在のターゲットラインを取得
-    /// </summary>
-    private LineObject GetCurrentTargetLine()
-    {
-        var lines = GetAllLinesOrdered(isS2G);
-        if (lines == null || lines.Count == 0) return null;
-
-        // 範囲外アクセスを防ぐためにClamp
-        int idx = Mathf.Clamp(currentTargetLineIndex + 1, 1, Mathf.Max(1, lines.Count - 1));
-        return lines[idx];
-    }
-
-    /// <summary>
-    /// 現在のソースラインを取得
-    /// </summary>
-    private LineObject GetCurrentSourceLine()
-    {
-        var lines = GetAllLinesOrdered(isS2G);
-        if (lines == null || lines.Count == 0) return null;
-
-        // 範囲外アクセスを防ぐためにClamp
-        int idx = Mathf.Clamp(currentTargetLineIndex, 0, Mathf.Max(0, lines.Count - 2));
-        return lines[idx];
-    }
-
-    // 目的地を設定：現在位置の対応点を次ターゲットライン上に求め、NavMeshAgentへ指示
-    private void SetDestination()
-    {
-        if (frontierStart == null || frontierGoal == null) return;
-        if (isStationaryPedestrian) return; // 停止者は目的地設定不要
-
-        // 現在位置に対する対応点から次の目的地を決定
-        Vector3 currentPosition = transform.position;
-        LineObject sourceLine = GetCurrentSourceLine();
-        LineObject targetLine = GetCurrentTargetLine();
-
-        destination = GetCorrespondingPointOnLine(currentPosition, sourceLine, targetLine);
-        navMeshAgent.SetDestination(destination);
-    }
-
-    // 進行方向に歩行者の向きを合わせる（Y軸回りのみ回転）
-    private void AlignWithDestination()
-    {
-        Vector3 direction = destination - transform.position;
-        direction.y = 0;
-
-        if (direction != Vector3.zero)
-        {
-            transform.rotation = Quaternion.LookRotation(direction);
-        }
     }
 
     // 通行ルールと逆走者フラグに基づき、左右通行側を決定
@@ -363,22 +344,36 @@ public class PedestrianController : MonoBehaviour
         }
     }
 
-    // 進行方向に対して+90度回転したベクトルを「左」として扱い、中心から左右へオフセット   
-    private Vector3 GetSidePositionOnLine(LineObject line, Vector3 forwardDir, bool useLeftSide, float offset)
+    /// <summary>
+    /// 指定セグメント（source→target）の進行方向に対し、歩行レーンの左半/右半から
+    /// lateral ratio（0..1）を選ぶ。LineObject.Left/Right と幾何学的な左/右は一致しない
+    /// 可能性があるため、毎回「進行方向の左ベクトル」に対して LeftPoint が左側かを判定する。
+    /// </summary>
+    private float ChooseLateralRatioForSegment(LineObject source, LineObject target, bool useLeft)
     {
-        // 進行方向に対して+90度回転したベクトルを「左」として扱い、中心から左右へオフセット
-        Vector3 center = line.GetCenter();
-        Vector3 leftDir = new Vector3(-forwardDir.z, 0f, forwardDir.x).normalized;
-        Vector3 result;
-        if (useLeftSide)
+        // forward（XZ）。退化時は line の Left→Right を代用する。
+        Vector3 forward = target.GetCenter() - source.GetCenter();
+        forward.y = 0f;
+        // ほぼゼロ区間の場合は source の Left→Right を代用
+        if (forward.sqrMagnitude < 0.01f)
         {
-            result = center + leftDir * offset;
+            forward = source.RightPoint - source.LeftPoint;
+            forward.y = 0f;
         }
+        forward.Normalize();
+
+        // 進行方向の「左」ベクトル（XZ）
+        Vector3 left = new Vector3(-forward.z, 0f, forward.x);
+
+        // source ラインの幾何学的な左側にある端点が LeftPoint かをチェック
+        Vector3 center = source.GetCenter();
+        bool leftPointIsGeometricLeft = Vector3.Dot(source.LeftPoint - center, left) >= 0f;
+
+        // 要求サイドに応じて半区間を選択
+        if (useLeft)
+            return leftPointIsGeometricLeft ? Random.Range(0f, 0.5f) : Random.Range(0.5f, 1f);
         else
-        {
-            result = center - leftDir * offset;
-        }
-        return result;
+            return leftPointIsGeometricLeft ? Random.Range(0.5f, 1f) : Random.Range(0f, 0.5f);
     }
 
     // NavMeshパラメータをランダムに適用
@@ -396,4 +391,5 @@ public class PedestrianController : MonoBehaviour
         navMeshAgent.avoidancePriority = Random.Range(0, 100);
         navMeshAgent.isStopped = false;
     }
+    #endregion
 }

--- a/Assets/Scripts/PedestrianController.cs
+++ b/Assets/Scripts/PedestrianController.cs
@@ -3,10 +3,15 @@ using UnityEngine.AI;
 using System.Collections.Generic;
 using Random = UnityEngine.Random;
 
+// NavMeshAgent を使って、Start→中間→Goal のライン群に沿って
+// 歩行者を制御するコンポーネント。
+// 左右通行・逆走・停止者を考慮し、到達後は位置をリセットして循環させる。
 [RequireComponent(typeof(NavMeshAgent))]
 public class PedestrianController : MonoBehaviour
 {
     // 外部参照
+    // - PopulationFlowManager: 左右通行設定などの共有コンフィグ
+    // - frontierStart/frontierGoal: 経路の始端・終端ライン
     [HideInInspector] public PopulationFlowManager PopulationFlowManager;
     [HideInInspector] public LineObject frontierStart, frontierGoal;
     /// <summary>
@@ -20,12 +25,12 @@ public class PedestrianController : MonoBehaviour
     public bool isReversePedestrian = false;    // 逆走者フラグ
 
     // 移動設定
-[Header("移動設定")]
+    [Header("移動設定")]
     [SerializeField] private float minSpeed = 0.5f;
     [SerializeField] private float maxSpeed = 3.0f;
 
     // y座標の補正設定
-    private float navMeshSnapMaxDistance = 2.0f; // 近傍NavMeshへスナップする最大距離（YはNavMesh/Agentで自動管理）
+    [SerializeField] private float navMeshSnapMaxDistance = 2.0f; // 近傍NavMeshへスナップする最大距離（YはNavMesh/Agentで自動管理）
 
     // 移動制御
     private NavMeshAgent navMeshAgent;
@@ -36,12 +41,24 @@ public class PedestrianController : MonoBehaviour
     private int currentTargetLineIndex = 0; // 次に目指すラインのインデックス（0～intermediateLines.Count）
     // - S2Gの場合: 0は最初の中間ライン（中間ライン無し時はゴールライン）、intermediateLines.Countはゴールライン
     // - G2Sの場合: 0は最初の目的ライン（ゴールライン）、intermediateLines.Countはスタートライン
-
+    
+    // 外部（Managerなど）から参照するためのキャッシュ済み Animator アクセサ
+    public Animator CachedAnimator => cachedAnimator;
 
     private void Awake()
     {
+        // 頻繁にアクセスするコンポーネント参照をキャッシュして、GetComponentの頻度を下げる
         navMeshAgent = GetComponent<NavMeshAgent>();
         cachedAnimator = GetComponent<Animator>();
+    }
+
+    // 指定座標に歩行者をワープさせる
+    private void WarpOrSetPosition(Vector3 position)
+    {
+        if (navMeshAgent.isActiveAndEnabled)
+            navMeshAgent.Warp(position);
+        else
+            transform.position = position;
     }
 
     // 歩行者の初期位置と方向を設定
@@ -49,61 +66,80 @@ public class PedestrianController : MonoBehaviour
     {
         if (frontierStart == null || frontierGoal == null) return;
 
-        // 中間ライン追跡状態をリセット
+        // 中間ライン追跡状態をリセット（最初のセグメントから再開）
         currentTargetLineIndex = 0;
 
+        // 初期位置と目的地を計算してセットアップ
         var positionData = CalculateInitialPosition(isLeftSideTraffic);
         SetupPedestrianAtPosition(positionData.position, positionData.destination);
 
-        // Animator制御：停止者の浮きを避けるため、可能なら有効のまま速度0にする
+        // Animator制御：可能なら有効化し、停止者はアニメ速度0、通常は1に設定
         var anim = cachedAnimator;
         if (anim != null)
         {
             anim.enabled = true;
-            anim.speed = isStationaryPedestrian ? 0f : 1f;
+            if (isStationaryPedestrian)
+            {
+                anim.speed = 0f;
+            }
+            else
+            {
+                anim.speed = 1f;
+            }
         }
     }
-
-    // 外部（Managerなど）から参照するためのキャッシュ済み Animator アクセサ
-    public Animator CachedAnimator => cachedAnimator;
 
     // 初期位置と目的地を計算
     private (Vector3 position, Vector3 destination) CalculateInitialPosition(bool isLeftSideTraffic)
     {
         var lines = GetAllLinesOrdered(isS2G);
+
+        // 初期セグメントの選定：両端(Start/Goal)を避け、中間セグメントを優先
         int minSegIndex = 1;
         int maxSegIndex = lines.Count - 2;
         int segIndex;
         if (minSegIndex >= maxSegIndex)
         {
-            segIndex = Mathf.Clamp(Mathf.FloorToInt((lines.Count - 1) * 0.5f), 0, Mathf.Max(0, lines.Count - 2));
+            Debug.LogWarning("ライン数が不足しています。スタート・ゴールを各１つ中間ライン２つ以上を設定してください。");
+            segIndex = Random.Range(0, lines.Count - 1);
         }
         else
         {
-            segIndex = Random.Range(minSegIndex, maxSegIndex); // maxSegIndex は排他
+            // minSegIndex 以上 maxSegIndex 未満の範囲でランダム選択
+            segIndex = Random.Range(minSegIndex, maxSegIndex);
         }
+
         LineObject src = lines[segIndex];
         LineObject dst = lines[segIndex + 1];
 
+        // セグメントの進行方向（中心点同士のベクトル）
         Vector3 forward = (dst.GetCenter() - src.GetCenter()).normalized;
+
+        // 通行ルール（左右通行）に対応するオフセット幅を決定
         float halfLen = src.GetLength() * 0.5f;
         bool useLeft = ShouldUseLeftSide(isLeftSideTraffic);
         float offset = Random.Range(0f, halfLen);
+
+        // src上の左右側点 p0 と、それに対応するdst上の点 p1 を取得
         Vector3 p0 = GetSidePositionOnLine(src, forward, useLeft, offset);
         Vector3 p1 = GetCorrespondingPointOnLine(p0, src, dst);
+
+        // p0-p1間のランダム位置を初期位置とする
         Vector3 spawnPos = Vector3.Lerp(p0, p1, Random.value);
+
+        // NavMesh上へスナップ
         Vector3 position = SnapToNavMeshXZ(spawnPos);
+
+        // 現在のターゲットセグメントを保持（source=segIndex, target=segIndex+1）
         currentTargetLineIndex = segIndex;
+
+        // 初期の目的地は p1（dst対応点）を使用
         return (position, p1);
     }
 
     /// <summary>
-    /// 全ラインを進行方向順に並べたリストを取得
+    /// 全ラインを進行方向順（S2G/G2S）に整列して返す
     /// </summary>
-    /// <remarks>初期化用: 外部からの呼び出しは想定しません</remarks>
-    /// </summary>
-    /// <param name="s2g">true: Start→Goal, false: Goal→Start</param>
-    /// <returns>進行方向順のラインリスト</returns>
     private List<LineObject> GetAllLinesOrdered(bool s2g)
     {
         var list = new List<LineObject> { frontierStart };
@@ -113,237 +149,36 @@ public class PedestrianController : MonoBehaviour
         }
         list.Add(frontierGoal);
 
+        // G2S の場合は反転
         if (!s2g)
         {
-            list.Reverse(); // G2S なら逆順で保持
+            list.Reverse();
         }
 
         return list;
     }
 
 
-    // リセット位置を計算（ソースラインと次の目的ラインを基準に算出）
-    private Vector3 CalculateResetPosition()
-    {
-        LineObject sourceLine = GetCurrentSourceLine();
-        LineObject targetLine = GetCurrentTargetLine();
-        if (sourceLine == null || targetLine == null) return transform.position;
-        Vector3 forward = (targetLine.GetCenter() - sourceLine.GetCenter()).normalized;
-        float halfLength = sourceLine.GetLength() * 0.5f;
-        bool useLeft = ShouldUseLeftSide(PopulationFlowManager.IsLeftSideTraffic);
-        float offset = Random.Range(0f, halfLength);
-        Vector3 basePos = GetSidePositionOnLine(sourceLine, forward, useLeft, offset);
-        return SnapToNavMeshXZ(basePos);
-    }
-
-    // 指定位置に歩行者をセットアップ
+    // 指定位置に歩行者をセットアップ（目的地設定・速度等の個体差を適用）
     private void SetupPedestrianAtPosition(Vector3 position, Vector3 targetDestination)
     {
         destination = targetDestination;
-        if (navMeshAgent.isActiveAndEnabled)
-        {
-            if (!navMeshAgent.Warp(position)) transform.position = position;
-        }
-        else
-        {
-            transform.position = position;
-        }
+        WarpOrSetPosition(position);
         ApplyRandomMovementParams();
         if (!isStationaryPedestrian)
         {
             navMeshAgent.SetDestination(destination);
-            AlignWithDestination();
+            AlignWithDestination(); // 初期向きを目的地方向に合わせる
         }
     }
 
-    // 近傍のNavMesh上にXZを維持したままスナップ（YはNavMesh基準）
-    private Vector3 SnapToNavMeshXZ(Vector3 approx)
-    {
-        NavMeshHit hit;
-        if (NavMesh.SamplePosition(approx, out hit, navMeshSnapMaxDistance, NavMesh.AllAreas))
-        {
-            return hit.position;
-        }
-        // 見つからない場合は現在の高さを維持して返す
-        return new Vector3(approx.x, transform.position.y, approx.z);
-    }
-
-    // ラインの適切な側からランダムな点を取得
-    private Vector3 GetRandomPointOnLineSide(LineObject sourceLine, LineObject destinationLine, bool useLeftSide)
-    {
-        Vector3 centerPoint = sourceLine.GetCenter();
-        float halfLength = sourceLine.GetLength() / 2f;
-
-        // sourceLineからdestinationLineへの方向ベクトル（実際のセグメント方向）
-        Vector3 forward = (destinationLine.GetCenter() - sourceLine.GetCenter()).normalized;
-
-        // 進行方向から見た左方向を計算（90度左回転）
-        Vector3 leftDirection = new Vector3(-forward.z, 0, forward.x).normalized;
-
-        // 逆走者の場合は通行位置を逆にする
-        bool effectiveUseLeftSide = isReversePedestrian ? !useLeftSide : useLeftSide;
-
-        float offset = Random.Range(0, halfLength);
-
-        // 左側通行者として位置を決定
-        if (effectiveUseLeftSide)
-        {
-            return centerPoint + leftDirection * offset;
-        }
-        // 右側通行者として位置を決定
-        else
-        {
-            return centerPoint - leftDirection * offset;
-        }
-    }
-
-    // あるライン上の点に対応する別のライン上の点を取得
-    private Vector3 GetCorrespondingPointOnLine(Vector3 sourcePoint, LineObject sourceLine, LineObject targetLine)
-    {
-        // ソースライン上での位置を0-1の比率として計算
-        Vector3 sourceLeft = sourceLine.LeftPoint;
-        Vector3 sourceRight = sourceLine.RightPoint;
-        Vector3 sourceVector = sourceRight - sourceLeft;
-
-        Vector3 toSourcePoint = sourcePoint - sourceLeft;
-        // 内積(Dot)を使って、点がラインに沿ってどれくらい進んだかを計算
-        float sourceRatio = Vector3.Dot(toSourcePoint, sourceVector.normalized) / sourceVector.magnitude;
-        // 0-1の範囲に収める（基本は元々0-1に収まっているが、例外もあり得る）
-        sourceRatio = Mathf.Clamp01(sourceRatio);
-
-        // ターゲットライン上の対応する位置を計算
-        Vector3 targetLeft = targetLine.LeftPoint;
-        Vector3 targetRight = targetLine.RightPoint;
-
-        return Vector3.Lerp(targetLeft, targetRight, sourceRatio);
-    }
-
-    /// <summary>
-    /// 現在のターゲットラインを取得（中間ライン対応）
-    /// </summary>
-    /// <returns>現在目指すべきLineObject</returns>
-    private LineObject GetCurrentTargetLine()
-    {
-        if (intermediateLines == null || intermediateLines.Count == 0)
-        {
-            // 中間ラインが無い場合
-            return isS2G ? frontierGoal : frontierStart;
-        }
-
-        if (isS2G)
-        {
-            // S2G: Start → mid[0] → mid[1] → ... → Goal
-            if (currentTargetLineIndex < intermediateLines.Count)
-            {
-                return intermediateLines[currentTargetLineIndex];
-            }
-            else
-            {
-                return frontierGoal; // 最終ゴール
-            }
-        }
-        else
-        {
-            // G2S: Goal → mid[N-1] → ... → mid[0] → Start (逆順)
-            int reversedIndex = intermediateLines.Count - 1 - currentTargetLineIndex;
-            if (reversedIndex >= 0)
-            {
-                return intermediateLines[reversedIndex];
-            }
-            else
-            {
-                return frontierStart; // 最終ゴール
-            }
-        }
-    }
-
-    /// <summary>
-    /// 現在位置から適切なソースラインを取得
-    /// </summary>
-    /// <returns>現在位置に対応するソースライン</returns>
-    private LineObject GetCurrentSourceLine()
-    {
-        if (intermediateLines == null || intermediateLines.Count == 0)
-        {
-            // 中間ラインが無い場合は従来通り
-            return isS2G ? frontierStart : frontierGoal;
-        }
-
-        if (isS2G)
-        {
-            // S2G: 最初はStart、その後は前の中間ライン
-            if (currentTargetLineIndex == 0)
-            {
-                return frontierStart;
-            }
-            else if (currentTargetLineIndex <= intermediateLines.Count)
-            {
-                return intermediateLines[currentTargetLineIndex - 1];
-            }
-            else
-            {
-                return intermediateLines[intermediateLines.Count - 1];
-            }
-        }
-        else
-        {
-            // G2S: 最初はGoal、その後は前の中間ライン（逆順）
-            if (currentTargetLineIndex == 0)
-            {
-                return frontierGoal;
-            }
-            else
-            {
-                int reversedIndex = intermediateLines.Count - currentTargetLineIndex;
-                if (reversedIndex >= 0 && reversedIndex < intermediateLines.Count)
-                {
-                    return intermediateLines[reversedIndex];
-                }
-                else
-                {
-                    return frontierStart;
-                }
-            }
-        }
-    }
-
-    // 目的地を設定
-    private void SetDestination()
-    {
-        if (frontierStart == null || frontierGoal == null) return;
-
-        // 停止者の場合は目的地設定を無視
-        if (isStationaryPedestrian) return;
-
-        Vector3 currentPosition = transform.position;
-        LineObject sourceLine = GetCurrentSourceLine();
-        LineObject targetLine = GetCurrentTargetLine();
-
-        destination = GetCorrespondingPointOnLine(currentPosition, sourceLine, targetLine);
-        navMeshAgent.SetDestination(destination);
-    }
-
-    // 進行方向に歩行者の向きを合わせる
-    private void AlignWithDestination()
-    {
-        Vector3 direction = destination - transform.position;
-        direction.y = 0; // Y軸は無視して水平方向だけ向きを合わせる
-
-        if (direction != Vector3.zero)
-        {
-            transform.rotation = Quaternion.LookRotation(direction);
-        }
-    }
-
-    // ラインに衝突した時の処理（中間ラインor最終ライン）
+        // ライン到達時
     private void OnTriggerEnter(Collider other)
     {
-        // 停止者の場合は衝突判定を無視
-        if (isStationaryPedestrian) return;
+        if (isStationaryPedestrian) return; // 停止者は衝突無視
 
-        // まず最終到達点かどうかをチェック（優先）
+        // 最終目的地到達チェック
         bool shouldReset = false;
-
         if (isS2G && frontierGoal != null && other.gameObject == frontierGoal.gameObject)
         {
             shouldReset = true;
@@ -355,34 +190,36 @@ public class PedestrianController : MonoBehaviour
 
         if (shouldReset)
         {
-            // 中間ライン追跡をリセット
+            // 到達後はセグメント進行を初期化して循環
             currentTargetLineIndex = 0;
             ResetPosition();
-            return; // 最終到達時は他の処理をスキップ
+            return;
         }
 
-        // 中間ライン到達チェック（最終到達でない場合のみ）
+        // 中間ライン到達チェック
         if (intermediateLines != null && intermediateLines.Count > 0)
         {
             LineObject currentTarget = GetCurrentTargetLine();
             if (currentTarget != null && other.gameObject == currentTarget.gameObject)
             {
-                // 次のラインに進む
+                // 次のターゲットへ進め、目的地を更新
                 currentTargetLineIndex++;
-
-                // 目的地を更新（次の中間ラインまたは最終ゴール）
                 SetDestination();
                 return;
             }
         }
     }
 
-    // 目的地を超えたら位置をリセットして再度歩行
+    // 目的地を超えたら位置をリセットして再度歩行開始（循環）
     private void ResetPosition()
     {
         if (frontierStart == null || frontierGoal == null || !navMeshAgent.isOnNavMesh) return;
+
+        // 再配置：現在のセグメントの左右半区間上にランダムに再配置
         Vector3 resetPosition = CalculateResetPosition();
-        if (navMeshAgent.isActiveAndEnabled) navMeshAgent.Warp(resetPosition); else transform.position = resetPosition;
+        WarpOrSetPosition(resetPosition);
+
+        // 目的地と移動パラメータを再設定
         SetDestination();
         ApplyRandomMovementParams();
         if (!isStationaryPedestrian)
@@ -391,27 +228,170 @@ public class PedestrianController : MonoBehaviour
         }
     }
 
+    // リセット位置を計算
+    // S2Gだったらスタートライン、G2Sだったらゴールラインの左右半区間上にランダムに再配置
+    private Vector3 CalculateResetPosition()
+    {
+        LineObject sourceLine, targetLine;
+        // Reset時のソース/ターゲットは経路の先頭側
+        if (isS2G)
+        {
+            sourceLine = frontierStart;
+            targetLine = (intermediateLines != null && intermediateLines.Count > 0)
+                ? intermediateLines[0]
+                : frontierGoal;
+        }
+        else
+        {
+            sourceLine = frontierGoal;
+            targetLine = (intermediateLines != null && intermediateLines.Count > 0)
+                ? intermediateLines[intermediateLines.Count - 1]
+                : frontierStart;
+        }
+
+        // 進行方向ベクトル
+        Vector3 forward = (targetLine.GetCenter() - sourceLine.GetCenter()).normalized;
+
+        // 片側幅の範囲でランダムオフセット
+        float halfLength = sourceLine.GetLength() * 0.5f;
+        bool useLeft = ShouldUseLeftSide(PopulationFlowManager.IsLeftSideTraffic);
+        float offset = Random.Range(0f, halfLength);
+
+        // 並進位置を算出し、NavMeshへスナップ
+        Vector3 basePos = GetSidePositionOnLine(sourceLine, forward, useLeft, offset);
+        return SnapToNavMeshXZ(basePos);
+    }
+
+    // 近傍のNavMesh上にXZを維持したままスナップ（見つからない時は高さのみ現状を保持して返す）
+    private Vector3 SnapToNavMeshXZ(Vector3 approx)
+    {
+        NavMeshHit hit;
+        if (NavMesh.SamplePosition(approx, out hit, navMeshSnapMaxDistance, NavMesh.AllAreas))
+        {
+            return hit.position;
+        }
+        // フォールバック：NavMeshが見つからない場合はXZのみ採用
+        return new Vector3(approx.x, transform.position.y, approx.z);
+    }
+
+    // あるライン上の点に対応する別ライン上の点を取得
+    private Vector3 GetCorrespondingPointOnLine(Vector3 sourcePoint, LineObject sourceLine, LineObject targetLine)
+    {
+        // sourceLine 左端→右端ベクトル
+        Vector3 sourceLeft = sourceLine.LeftPoint;
+        Vector3 sourceRight = sourceLine.RightPoint;
+        Vector3 sourceVector = sourceRight - sourceLeft;
+
+        // sourcePoint が sourceLine 上でどの割合(0-1)に位置するかを内積から求める
+        float sourceRatio = 0f;
+        float denom = sourceVector.sqrMagnitude;
+        if (denom > Mathf.Epsilon)
+        {
+            sourceRatio = Mathf.Clamp01(Vector3.Dot(sourcePoint - sourceLeft, sourceVector) / denom);
+        }
+
+        // 求めた比率で targetLine の対応点を補間
+        Vector3 targetLeft = targetLine.LeftPoint;
+        Vector3 targetRight = targetLine.RightPoint;
+        return Vector3.Lerp(targetLeft, targetRight, sourceRatio);
+    }
+
+    /// <summary>
+    /// 現在のターゲットラインを取得
+    /// </summary>
+    private LineObject GetCurrentTargetLine()
+    {
+        var lines = GetAllLinesOrdered(isS2G);
+        if (lines == null || lines.Count == 0) return null;
+
+        // 範囲外アクセスを防ぐためにClamp
+        int idx = Mathf.Clamp(currentTargetLineIndex + 1, 1, Mathf.Max(1, lines.Count - 1));
+        return lines[idx];
+    }
+
+    /// <summary>
+    /// 現在のソースラインを取得
+    /// </summary>
+    private LineObject GetCurrentSourceLine()
+    {
+        var lines = GetAllLinesOrdered(isS2G);
+        if (lines == null || lines.Count == 0) return null;
+
+        // 範囲外アクセスを防ぐためにClamp
+        int idx = Mathf.Clamp(currentTargetLineIndex, 0, Mathf.Max(0, lines.Count - 2));
+        return lines[idx];
+    }
+
+    // 目的地を設定：現在位置の対応点を次ターゲットライン上に求め、NavMeshAgentへ指示
+    private void SetDestination()
+    {
+        if (frontierStart == null || frontierGoal == null) return;
+        if (isStationaryPedestrian) return; // 停止者は目的地設定不要
+
+        // 現在位置に対する対応点から次の目的地を決定
+        Vector3 currentPosition = transform.position;
+        LineObject sourceLine = GetCurrentSourceLine();
+        LineObject targetLine = GetCurrentTargetLine();
+
+        destination = GetCorrespondingPointOnLine(currentPosition, sourceLine, targetLine);
+        navMeshAgent.SetDestination(destination);
+    }
+
+    // 進行方向に歩行者の向きを合わせる（Y軸回りのみ回転）
+    private void AlignWithDestination()
+    {
+        Vector3 direction = destination - transform.position;
+        direction.y = 0;
+
+        if (direction != Vector3.zero)
+        {
+            transform.rotation = Quaternion.LookRotation(direction);
+        }
+    }
+
+    // 通行ルールと逆走者フラグに基づき、左右通行側を決定
     private bool ShouldUseLeftSide(bool globalIsLeftSideTraffic)
     {
-        // 逆走者は左右を反転
-        return isReversePedestrian ? !globalIsLeftSideTraffic : globalIsLeftSideTraffic;
+        // 逆走者は左右通行を反転させる
+        if (isReversePedestrian)
+        {
+            return !globalIsLeftSideTraffic;
+        }
+        else
+        {
+            return globalIsLeftSideTraffic;
+        }
     }
 
+    // 進行方向に対して+90度回転したベクトルを「左」として扱い、中心から左右へオフセット   
     private Vector3 GetSidePositionOnLine(LineObject line, Vector3 forwardDir, bool useLeftSide, float offset)
     {
+        // 進行方向に対して+90度回転したベクトルを「左」として扱い、中心から左右へオフセット
         Vector3 center = line.GetCenter();
         Vector3 leftDir = new Vector3(-forwardDir.z, 0f, forwardDir.x).normalized;
-        return useLeftSide ? center + leftDir * offset : center - leftDir * offset;
+        Vector3 result;
+        if (useLeftSide)
+        {
+            result = center + leftDir * offset;
+        }
+        else
+        {
+            result = center - leftDir * offset;
+        }
+        return result;
     }
 
+    // NavMeshパラメータをランダムに適用
     private void ApplyRandomMovementParams()
     {
+        // 停止者は速度0/停止。移動者は速度と回避優先度にランダム性を付与
         if (isStationaryPedestrian)
         {
             navMeshAgent.speed = 0f;
             navMeshAgent.isStopped = true;
             return;
         }
+
         navMeshAgent.speed = Random.Range(minSpeed, maxSpeed);
         navMeshAgent.avoidancePriority = Random.Range(0, 100);
         navMeshAgent.isStopped = false;

--- a/Assets/Scripts/PopulationFlowManager.cs
+++ b/Assets/Scripts/PopulationFlowManager.cs
@@ -106,7 +106,7 @@ public class PopulationFlowManager : MonoBehaviour
     // PedestrianControllerの共通設定
     private void SetupPedestrianController(PedestrianController controller, bool isS2G)
     {
-        controller.PopulationFlowManager = this;
+        controller.populationFlowManager = this;
         controller.frontierStart = frontierStart;
         controller.frontierGoal = frontierGoal;
         controller.intermediateLines = intermediateLines;

--- a/Assets/unity-chan!.meta
+++ b/Assets/unity-chan!.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89838b2c936e69d4abb2e9a465305b87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,12 +3,13 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Target
   layers:
   - Default
   - TransparentFX
   - Ignore Raycast
-  - 
+  - Road
   - Water
   - UI
   - 


### PR DESCRIPTION
# 概要

- 冗長であったPedestrianController.csをリファクタし、スクリプトを簡易的に


## 具体

1. 横割合の固定化
    - 生成/リセット時に進行方向の左右半区間から点をサンプリングし、そのライン比率を lateralRatio として保持。
    - 以後の各セグメント目的地は Vector3.Lerp(target.LeftPoint, target.RightPoint, lateralRatio) で決定。
 
2.  リセット時の参照ラインを明示

3. ライン配列のキャッシュ
    - ライン列の構築を初期生成・リセット時のみに
  
4. 関数の並べ順
    - regionを使用し、スコープやイベント毎によって、関数の並び順を変更