### PR TITLE
歩行者の身長をランダムに

### DIFF
--- a/Assets/Prefabs/Animated Human.prefab
+++ b/Assets/Prefabs/Animated Human.prefab
@@ -62,7 +62,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 2361e03d0da06e14e9329cddc09a1695, type: 3}
       propertyPath: m_ConstrainProportionsScale
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 2361e03d0da06e14e9329cddc09a1695, type: 3}
       propertyPath: m_Name
@@ -203,7 +203,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e5016dda1a90794c94281e2de8a351f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PopulationFlowManager: {fileID: 0}
+  populationFlowManager: {fileID: 0}
   frontierStart: {fileID: 0}
   frontierGoal: {fileID: 0}
   intermediateLines: []
@@ -212,3 +212,5 @@ MonoBehaviour:
   isReversePedestrian: 0
   minSpeed: 0.5
   maxSpeed: 3
+  MinHeightScale: 0.5
+  MaxHeightScale: 1.5

--- a/Assets/Scripts/PedestrianController.cs
+++ b/Assets/Scripts/PedestrianController.cs
@@ -30,13 +30,19 @@ public class PedestrianController : MonoBehaviour
     [SerializeField] private float minSpeed = 0.5f;
     [SerializeField] private float maxSpeed = 3.0f;
 
+    // 身長スケール設定（1.0が基準）
+    [Header("身長スケール設定")]
+    [SerializeField] private float MinHeightScale = 0.85f;
+    [SerializeField] private float MaxHeightScale = 1.15f;
+
     // y座標の補正設定
-    [SerializeField] private float navMeshSnapMaxDistance = 2.0f; // 近傍NavMeshへスナップする最大距離（YはNavMesh/Agentで自動管理）
+    private float navMeshSnapMaxDistance = 2.0f; // 近傍NavMeshへスナップする最大距離（YはNavMesh/Agentで自動管理）
 
     // 移動制御
     private NavMeshAgent navMeshAgent;
     private Vector3 destination;
     private Animator cachedAnimator;
+    private Vector3 originalScale; // プレハブの元のスケールを保持
     // サイクル（生成〜到達）中に維持する横方向の割合（0..1）
     private float lateralRatio = 0.5f;
 
@@ -58,6 +64,7 @@ public class PedestrianController : MonoBehaviour
     {
         navMeshAgent = GetComponent<NavMeshAgent>();
         cachedAnimator = GetComponent<Animator>();
+        originalScale = transform.localScale; // 元のスケールを保持
     }
     #endregion
 
@@ -378,6 +385,10 @@ public class PedestrianController : MonoBehaviour
     // NavMeshパラメータをランダムに適用
     private void ApplyRandomMovementParams()
     {
+        // 身長スケールをランダムに適用（元のスケールを基準に乗算）
+        float heightScale = Random.Range(MinHeightScale, MaxHeightScale);
+        transform.localScale = originalScale * heightScale;
+
         // 停止者は速度0/停止。移動者は速度と回避優先度にランダム性を付与
         if (isStationaryPedestrian)
         {


### PR DESCRIPTION
## 背景
- #2 

## 具体
- 初期のtransform.scaleを保持しておき、それに対してランダムにスケーリング
- yだけスケーリングするのではなく、x/y/z均一にスケーリングしている（体形のバランスは維持）